### PR TITLE
Add Archlinux Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ https://github.com/kz6fittycent/whatami/pulls
 
 `sudo snap install whatami`
 
+## Install on Arch Linux with AUR
+
+`yay -S whatami-git`
+
 ## Run it
     
 * With ascii - `whatami`


### PR DESCRIPTION
Hello, I've package this for arch linux (BTW), some time ago, So I've just add documentation about how to install this on arch (which I use BTW) in this readme.

Sorry for the meme in the PR description, it's because I use Arch BTW